### PR TITLE
New models for scan result with hierarchy for both soap and priority APIs

### DIFF
--- a/Checkmarx.API.Tests/ScanTests.cs
+++ b/Checkmarx.API.Tests/ScanTests.cs
@@ -18,6 +18,7 @@ using System.Xml;
 using System.Xml.Linq;
 using Checkmarx.API;
 using Checkmarx.API.Exceptions;
+using Checkmarx.API.Models;
 using cxPriorityWebService;
 using Microsoft.Extensions.Configuration;
 using Microsoft.OData.Client;
@@ -395,9 +396,9 @@ namespace Checkmarx.API.Tests
                     // New, Fixed, Recorrence
                     var resultByType = severity.GroupBy(x => x.ResultStatus).ToDictionary(x => x.Key);
 
-                    csvFields.Add(!resultByType.ContainsKey(PortalSoap.CompareStatusType.New) ? 0 : resultByType[PortalSoap.CompareStatusType.New].Count());
-                    csvFields.Add(!resultByType.ContainsKey(PortalSoap.CompareStatusType.Fixed) ? 0 : resultByType[PortalSoap.CompareStatusType.Fixed].Count());
-                    csvFields.Add(!resultByType.ContainsKey(PortalSoap.CompareStatusType.Reoccured) ? 0 : resultByType[PortalSoap.CompareStatusType.Reoccured].Count());
+                    csvFields.Add(!resultByType.ContainsKey(ResultStatus.New) ? 0 : resultByType[ResultStatus.New].Count());
+                    csvFields.Add(!resultByType.ContainsKey(ResultStatus.Fixed) ? 0 : resultByType[ResultStatus.Fixed].Count());
+                    csvFields.Add(!resultByType.ContainsKey(ResultStatus.Reoccured) ? 0 : resultByType[ResultStatus.Reoccured].Count());
 
                     csvFields.Add(query.Status.ToString());
 
@@ -527,7 +528,7 @@ namespace Checkmarx.API.Tests
                             {
                                 var pathhistory = clientV93.GetPathCommentsHistory(scan.Id, result.PathId);
 
-                                var uri = Utils.GetLink(result, clientV93, 1, scan.Id);
+                                var uri = result.GetLink(clientV93, 1, scan.Id);
 
                                 stringBuilder.AppendLine($"<a href=\"{uri.AbsoluteUri}\">{uri.AbsoluteUri}</a>");
 
@@ -851,24 +852,24 @@ namespace Checkmarx.API.Tests
         {
             try
             {
-                var resultProperties = typeof(PortalSoap.CxWSSingleResultData).GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.GetProperty);
+                var resultProperties = typeof(SoapSingleResultData).GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.GetProperty);
 
                 Trace.WriteLine("Property values using PortalSoap");
-                var results = clientV9.GetResultsForScan(2013131); // Portal SOAP 
+                var results = clientV93.GetResultsForScan(1893801); // Portal SOAP 
                 foreach (var result in results)
                 {
                     foreach (var property in resultProperties)
                         Trace.WriteLine(property.Name + ": " + property.GetValue(result));
                 }
 
-                //Trace.WriteLine("");
-                //Trace.WriteLine("Property values using Priority");
-                //var resultsPriority = clientV9.GetResultsForScan(2013131, usePriority: true); // Priority
-                //foreach (var result in resultsPriority)
-                //{
-                //    foreach (var property in resultProperties)
-                //        Trace.WriteLine(property.Name + ": " + property.GetValue(result));
-                //}
+                Trace.WriteLine("");
+                Trace.WriteLine("Property values using Priority");
+                var resultsPriority = clientV93.GetResultsForScan(1893801, usePriority: true); // Priority
+                foreach (var result in resultsPriority)
+                {
+                    foreach (var property in resultProperties)
+                        Trace.WriteLine(property.Name + ": " + property.GetValue(result));
+                }
             }
             catch (Exception ex)
             {

--- a/Checkmarx.API.Tests/ScanTests.cs
+++ b/Checkmarx.API.Tests/ScanTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Configuration;
 using System.Diagnostics;
+using System.Dynamic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -832,24 +833,15 @@ namespace Checkmarx.API.Tests
         public void GetXSSResultsTest()
         {
             var results = clientV93.GetResultsForScan(2013975); // SOAP ...
-
             Trace.WriteLine("Count: " + results.Count());
             foreach (var result in results)
-            {
                 Trace.WriteLine(result.QueryId + ";" + result.QueryVersionCode);
-            }
-
 
             var odataResults = clientV93.GetODataV95Results(2013975); // OData
-            
             Trace.WriteLine("ODATA Count: " + odataResults.Count());
-
             foreach (var odataResult in odataResults)
-            {
                 Trace.WriteLine(odataResult.QueryId + ";" + odataResult.QueryVersionId + ";" + odataResult.Query.Name);
-            }
 
-           
             Assert.AreEqual(odataResults.Count(), results.Count(), "The results from OData and SOAP should be equal");
         }
 
@@ -857,18 +849,31 @@ namespace Checkmarx.API.Tests
         [TestMethod]
         public void PriorityAPIGetScanResultsTest()
         {
-            var results = clientV93.GetResultsForScan(2013975); // SOAP ...
-
-            var resultProperties = typeof(CxWSResponseScanResultsPriority).GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.GetProperty);
-
-            foreach (var result in results.Take(1))
+            try
             {
-                foreach (var property in resultProperties)
-                {
-                    Trace.WriteLine(property.Name + ": " + property.GetValue(result));
-                }
-            }
+                var resultProperties = typeof(PortalSoap.CxWSSingleResultData).GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.GetProperty);
 
+                Trace.WriteLine("Property values using PortalSoap");
+                var results = clientV9.GetResultsForScan(2013131); // Portal SOAP 
+                foreach (var result in results)
+                {
+                    foreach (var property in resultProperties)
+                        Trace.WriteLine(property.Name + ": " + property.GetValue(result));
+                }
+
+                //Trace.WriteLine("");
+                //Trace.WriteLine("Property values using Priority");
+                //var resultsPriority = clientV9.GetResultsForScan(2013131, usePriority: true); // Priority
+                //foreach (var result in resultsPriority)
+                //{
+                //    foreach (var property in resultProperties)
+                //        Trace.WriteLine(property.Name + ": " + property.GetValue(result));
+                //}
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine(ex.Message);
+            }
         }
     }
 }

--- a/Checkmarx.API/Checkmarx.API.csproj
+++ b/Checkmarx.API/Checkmarx.API.csproj
@@ -24,26 +24,32 @@ It also provides access to the Access Control API.</Description>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>VSSpell001</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>VSSpell001</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>VSSpell001</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>VSSpell001</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Publish|AnyCPU'">
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>VSSpell001</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Publish|x64'">
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>VSSpell001</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Checkmarx.API/Connected Services/PortalSoap/Reference.cs
+++ b/Checkmarx.API/Connected Services/PortalSoap/Reference.cs
@@ -22181,7 +22181,7 @@ namespace PortalSoap
             return base.Channel.GetResultsForScanByLanguageAsync(sessionID, scanId, Language);
         }
 
-        public PortalSoap.CxWSResponceScanResults GetResultsForScan(string sessionID, long scanId)
+        internal PortalSoap.CxWSResponceScanResults GetResultsForScan(string sessionID, long scanId)
         {
             return base.Channel.GetResultsForScan(sessionID, scanId);
         }

--- a/Checkmarx.API/Connected Services/cxPriorityWebService/Reference.cs
+++ b/Checkmarx.API/Connected Services/cxPriorityWebService/Reference.cs
@@ -1650,7 +1650,7 @@ namespace cxPriorityWebService
             return base.Channel.GetResultsForScan(request);
         }
 
-        public cxPriorityWebService.CxWSResponseScanResultsPriority GetResultsForScan(string sessionID, long scanId)
+        internal cxPriorityWebService.CxWSResponseScanResultsPriority GetResultsForScan(string sessionID, long scanId)
         {
             cxPriorityWebService.GetResultsForScanRequest inValue = new cxPriorityWebService.GetResultsForScanRequest();
             inValue.Body = new cxPriorityWebService.GetResultsForScanRequestBody();

--- a/Checkmarx.API/Connected Services/cxPriorityWebService/Reference.cs
+++ b/Checkmarx.API/Connected Services/cxPriorityWebService/Reference.cs
@@ -9,9 +9,9 @@
 
 namespace cxPriorityWebService
 {
-    using cxPortalWebService93;
+    using Checkmarx.API;
     using System;
-    using System.Runtime.Serialization;
+    using System.Linq;
     using System.ServiceModel;
 
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -63,7 +63,7 @@ namespace cxPriorityWebService
         
         private bool CxMnoInstalledField;
         
-        private int TotalResultsCountField;
+        private int? TotalResultsCountField;
         
         [System.Runtime.Serialization.DataMemberAttribute(EmitDefaultValue=false)]
         public cxPriorityWebService.CxWSSingleResultDataPriority[] Results
@@ -103,9 +103,10 @@ namespace cxPriorityWebService
                 this.CxMnoInstalledField = value;
             }
         }
-        
-        [System.Runtime.Serialization.DataMemberAttribute(IsRequired=true, Order=3)]
-        public int TotalResultsCount
+
+        // It should stay as IsRequired=false -> Bellow version 9.4 the response does not contain total results count
+        [System.Runtime.Serialization.DataMemberAttribute(IsRequired=false, Order=3)]
+        public int? TotalResultsCount
         {
             get
             {
@@ -121,48 +122,48 @@ namespace cxPriorityWebService
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.1.0")]
     [System.Runtime.Serialization.DataContractAttribute(Name="CxWSSingleResultDataPriority", Namespace="http://Checkmarx.com")]
-    public partial class CxWSSingleResultDataPriority : PortalSoap.CxWSSingleResultData
+    public partial class CxWSSingleResultDataPriority
     {
 
-        //private long QueryIdField;
+        private long QueryIdField;
 
-        //private long PathIdField;
+        private long PathIdField;
 
-        //private string SourceFolderField;
+        private string SourceFolderField;
 
-        //private string SourceFileField;
+        private string SourceFileField;
 
-        //private long SourceLineField;
+        private long SourceLineField;
 
-        //private string SourceObjectField;
+        private string SourceObjectField;
 
-        //private string DestFolderField;
+        private string DestFolderField;
 
-        //private string DestFileField;
+        private string DestFileField;
 
-        //private long DestLineField;
+        private long DestLineField;
 
         private long SimilarityIDField;
 
-        //private int NumberOfNodesField;
+        private int NumberOfNodesField;
 
-        //private string DestObjectField;
+        private string DestObjectField;
 
-        //private string CommentField;
+        private string CommentField;
 
-        //private int StateField;
+        private int StateField;
 
-        //private int SeverityField;
+        private int SeverityField;
 
-        //private string AssignedUserField;
+        private string AssignedUserField;
 
-        //private System.Nullable<int> ConfidenceLevelField;
+        private System.Nullable<int> ConfidenceLevelField;
 
-        //private CompareStatusType ResultStatusField;
+        private CompareStatusType ResultStatusField;
 
-        //private string IssueTicketIDField;
+        private string IssueTicketIDField;
 
-        //private long QueryVersionCodeField;
+        private long QueryVersionCodeField;
 
         private System.Nullable<double> CxRankField;
 
@@ -172,122 +173,122 @@ namespace cxPriorityWebService
 
         private System.Nullable<System.DateTime> DateField;
 
-        //[System.Runtime.Serialization.DataMemberAttribute(IsRequired = true)]
-        //public long QueryId
-        //{
-        //    get
-        //    {
-        //        return this.QueryIdField;
-        //    }
-        //    set
-        //    {
-        //        this.QueryIdField = value;
-        //    }
-        //}
+        [System.Runtime.Serialization.DataMemberAttribute(IsRequired = true)]
+        public long QueryId
+        {
+            get
+            {
+                return this.QueryIdField;
+            }
+            set
+            {
+                this.QueryIdField = value;
+            }
+        }
 
-        //[System.Runtime.Serialization.DataMemberAttribute(IsRequired = true, Order = 1)]
-        //public long PathId
-        //{
-        //    get
-        //    {
-        //        return this.PathIdField;
-        //    }
-        //    set
-        //    {
-        //        this.PathIdField = value;
-        //    }
-        //}
+        [System.Runtime.Serialization.DataMemberAttribute(IsRequired = true, Order = 1)]
+        public long PathId
+        {
+            get
+            {
+                return this.PathIdField;
+            }
+            set
+            {
+                this.PathIdField = value;
+            }
+        }
 
-        //[System.Runtime.Serialization.DataMemberAttribute(EmitDefaultValue = false, Order = 2)]
-        //public string SourceFolder
-        //{
-        //    get
-        //    {
-        //        return this.SourceFolderField;
-        //    }
-        //    set
-        //    {
-        //        this.SourceFolderField = value;
-        //    }
-        //}
+        [System.Runtime.Serialization.DataMemberAttribute(EmitDefaultValue = false, Order = 2)]
+        public string SourceFolder
+        {
+            get
+            {
+                return this.SourceFolderField;
+            }
+            set
+            {
+                this.SourceFolderField = value;
+            }
+        }
 
-        //[System.Runtime.Serialization.DataMemberAttribute(EmitDefaultValue = false, Order = 3)]
-        //public string SourceFile
-        //{
-        //    get
-        //    {
-        //        return this.SourceFileField;
-        //    }
-        //    set
-        //    {
-        //        this.SourceFileField = value;
-        //    }
-        //}
+        [System.Runtime.Serialization.DataMemberAttribute(EmitDefaultValue = false, Order = 3)]
+        public string SourceFile
+        {
+            get
+            {
+                return this.SourceFileField;
+            }
+            set
+            {
+                this.SourceFileField = value;
+            }
+        }
 
-        //[System.Runtime.Serialization.DataMemberAttribute(IsRequired = true, Order = 4)]
-        //public long SourceLine
-        //{
-        //    get
-        //    {
-        //        return this.SourceLineField;
-        //    }
-        //    set
-        //    {
-        //        this.SourceLineField = value;
-        //    }
-        //}
+        [System.Runtime.Serialization.DataMemberAttribute(IsRequired = true, Order = 4)]
+        public long SourceLine
+        {
+            get
+            {
+                return this.SourceLineField;
+            }
+            set
+            {
+                this.SourceLineField = value;
+            }
+        }
 
-        //[System.Runtime.Serialization.DataMemberAttribute(EmitDefaultValue = false, Order = 5)]
-        //public string SourceObject
-        //{
-        //    get
-        //    {
-        //        return this.SourceObjectField;
-        //    }
-        //    set
-        //    {
-        //        this.SourceObjectField = value;
-        //    }
-        //}
+        [System.Runtime.Serialization.DataMemberAttribute(EmitDefaultValue = false, Order = 5)]
+        public string SourceObject
+        {
+            get
+            {
+                return this.SourceObjectField;
+            }
+            set
+            {
+                this.SourceObjectField = value;
+            }
+        }
 
-        //[System.Runtime.Serialization.DataMemberAttribute(EmitDefaultValue = false, Order = 6)]
-        //public string DestFolder
-        //{
-        //    get
-        //    {
-        //        return this.DestFolderField;
-        //    }
-        //    set
-        //    {
-        //        this.DestFolderField = value;
-        //    }
-        //}
+        [System.Runtime.Serialization.DataMemberAttribute(EmitDefaultValue = false, Order = 6)]
+        public string DestFolder
+        {
+            get
+            {
+                return this.DestFolderField;
+            }
+            set
+            {
+                this.DestFolderField = value;
+            }
+        }
 
-        //[System.Runtime.Serialization.DataMemberAttribute(EmitDefaultValue = false, Order = 7)]
-        //public string DestFile
-        //{
-        //    get
-        //    {
-        //        return this.DestFileField;
-        //    }
-        //    set
-        //    {
-        //        this.DestFileField = value;
-        //    }
-        //}
+        [System.Runtime.Serialization.DataMemberAttribute(EmitDefaultValue = false, Order = 7)]
+        public string DestFile
+        {
+            get
+            {
+                return this.DestFileField;
+            }
+            set
+            {
+                this.DestFileField = value;
+            }
+        }
 
-        //[System.Runtime.Serialization.DataMemberAttribute(IsRequired = true, Order = 8)]
-        //public long DestLine
-        //{
-        //    get
-        //    {
-        //        return this.DestLineField;
-        //    }
-        //    set
-        //    {
-        //        this.DestLineField = value;
-        //    }
-        //}
+        [System.Runtime.Serialization.DataMemberAttribute(IsRequired = true, Order = 8)]
+        public long DestLine
+        {
+            get
+            {
+                return this.DestLineField;
+            }
+            set
+            {
+                this.DestLineField = value;
+            }
+        }
 
         [System.Runtime.Serialization.DataMemberAttribute(IsRequired = false, Order = 9)]
         public long SimilarityID
@@ -302,135 +303,135 @@ namespace cxPriorityWebService
             }
         }
 
-        //[System.Runtime.Serialization.DataMemberAttribute(IsRequired = true, Order = 10)]
-        //public int NumberOfNodes
-        //{
-        //    get
-        //    {
-        //        return this.NumberOfNodesField;
-        //    }
-        //    set
-        //    {
-        //        this.NumberOfNodesField = value;
-        //    }
-        //}
+        [System.Runtime.Serialization.DataMemberAttribute(IsRequired = true, Order = 10)]
+        public int NumberOfNodes
+        {
+            get
+            {
+                return this.NumberOfNodesField;
+            }
+            set
+            {
+                this.NumberOfNodesField = value;
+            }
+        }
 
-        //[System.Runtime.Serialization.DataMemberAttribute(EmitDefaultValue = false, Order = 11)]
-        //public string DestObject
-        //{
-        //    get
-        //    {
-        //        return this.DestObjectField;
-        //    }
-        //    set
-        //    {
-        //        this.DestObjectField = value;
-        //    }
-        //}
+        [System.Runtime.Serialization.DataMemberAttribute(EmitDefaultValue = false, Order = 11)]
+        public string DestObject
+        {
+            get
+            {
+                return this.DestObjectField;
+            }
+            set
+            {
+                this.DestObjectField = value;
+            }
+        }
 
-        //[System.Runtime.Serialization.DataMemberAttribute(EmitDefaultValue = false, Order = 12)]
-        //public string Comment
-        //{
-        //    get
-        //    {
-        //        return this.CommentField;
-        //    }
-        //    set
-        //    {
-        //        this.CommentField = value;
-        //    }
-        //}
+        [System.Runtime.Serialization.DataMemberAttribute(EmitDefaultValue = false, Order = 12)]
+        public string Comment
+        {
+            get
+            {
+                return this.CommentField;
+            }
+            set
+            {
+                this.CommentField = value;
+            }
+        }
 
-        //[System.Runtime.Serialization.DataMemberAttribute(IsRequired = true, Order = 13)]
-        //public int State
-        //{
-        //    get
-        //    {
-        //        return this.StateField;
-        //    }
-        //    set
-        //    {
-        //        this.StateField = value;
-        //    }
-        //}
+        [System.Runtime.Serialization.DataMemberAttribute(IsRequired = true, Order = 13)]
+        public int State
+        {
+            get
+            {
+                return this.StateField;
+            }
+            set
+            {
+                this.StateField = value;
+            }
+        }
 
-        //[System.Runtime.Serialization.DataMemberAttribute(IsRequired = true, Order = 14)]
-        //public int Severity
-        //{
-        //    get
-        //    {
-        //        return this.SeverityField;
-        //    }
-        //    set
-        //    {
-        //        this.SeverityField = value;
-        //    }
-        //}
+        [System.Runtime.Serialization.DataMemberAttribute(IsRequired = true, Order = 14)]
+        public int Severity
+        {
+            get
+            {
+                return this.SeverityField;
+            }
+            set
+            {
+                this.SeverityField = value;
+            }
+        }
 
-        //[System.Runtime.Serialization.DataMemberAttribute(EmitDefaultValue = false, Order = 15)]
-        //public string AssignedUser
-        //{
-        //    get
-        //    {
-        //        return this.AssignedUserField;
-        //    }
-        //    set
-        //    {
-        //        this.AssignedUserField = value;
-        //    }
-        //}
+        [System.Runtime.Serialization.DataMemberAttribute(EmitDefaultValue = false, Order = 15)]
+        public string AssignedUser
+        {
+            get
+            {
+                return this.AssignedUserField;
+            }
+            set
+            {
+                this.AssignedUserField = value;
+            }
+        }
 
-        //[System.Runtime.Serialization.DataMemberAttribute(IsRequired = true, Order = 16)]
-        //public System.Nullable<int> ConfidenceLevel
-        //{
-        //    get
-        //    {
-        //        return this.ConfidenceLevelField;
-        //    }
-        //    set
-        //    {
-        //        this.ConfidenceLevelField = value;
-        //    }
-        //}
+        [System.Runtime.Serialization.DataMemberAttribute(IsRequired = true, Order = 16)]
+        public System.Nullable<int> ConfidenceLevel
+        {
+            get
+            {
+                return this.ConfidenceLevelField;
+            }
+            set
+            {
+                this.ConfidenceLevelField = value;
+            }
+        }
 
-        //[System.Runtime.Serialization.DataMemberAttribute(IsRequired = true, Order = 17)]
-        //public ServiceReference1.CompareStatusType ResultStatus
-        //{
-        //    get
-        //    {
-        //        return this.ResultStatusField;
-        //    }
-        //    set
-        //    {
-        //        this.ResultStatusField = value;
-        //    }
-        //}
+        [System.Runtime.Serialization.DataMemberAttribute(IsRequired = true, Order = 17)]
+        public CompareStatusType ResultStatus
+        {
+            get
+            {
+                return this.ResultStatusField;
+            }
+            set
+            {
+                this.ResultStatusField = value;
+            }
+        }
 
-        //[System.Runtime.Serialization.DataMemberAttribute(EmitDefaultValue = false, Order = 18)]
-        //public string IssueTicketID
-        //{
-        //    get
-        //    {
-        //        return this.IssueTicketIDField;
-        //    }
-        //    set
-        //    {
-        //        this.IssueTicketIDField = value;
-        //    }
-        //}
+        [System.Runtime.Serialization.DataMemberAttribute(EmitDefaultValue = false, Order = 18)]
+        public string IssueTicketID
+        {
+            get
+            {
+                return this.IssueTicketIDField;
+            }
+            set
+            {
+                this.IssueTicketIDField = value;
+            }
+        }
 
-        //[System.Runtime.Serialization.DataMemberAttribute(IsRequired = true, Order = 19)]
-        //public long QueryVersionCode
-        //{
-        //    get
-        //    {
-        //        return this.QueryVersionCodeField;
-        //    }
-        //    set
-        //    {
-        //        this.QueryVersionCodeField = value;
-        //    }
-        //}
+        [System.Runtime.Serialization.DataMemberAttribute(IsRequired = true, Order = 19)]
+        public long QueryVersionCode
+        {
+            get
+            {
+                return this.QueryVersionCodeField;
+            }
+            set
+            {
+                this.QueryVersionCodeField = value;
+            }
+        }
 
 
         [System.Runtime.Serialization.DataMemberAttribute(IsRequired = true, Order = 20)]
@@ -1648,7 +1649,12 @@ namespace cxPriorityWebService
         {
             return base.Channel.GetResultsForScan(request);
         }
-        
+
+        internal PortalSoap.CxWSResponceScanResults GetMappedResultsForScan(string sessionID, long scanId)
+        {
+            return MapPriorityResultsToSoapResults(GetResultsForScan(sessionID, scanId));
+        }
+
         public cxPriorityWebService.CxWSResponseScanResultsPriority GetResultsForScan(string sessionID, long scanId)
         {
             cxPriorityWebService.GetResultsForScanRequest inValue = new cxPriorityWebService.GetResultsForScanRequest();
@@ -1956,5 +1962,42 @@ namespace cxPriorityWebService
             
             CxPriorityServiceSoap12,
         }
+
+        #region Mapping
+
+        private PortalSoap.CxWSResponceScanResults MapPriorityResultsToSoapResults(cxPriorityWebService.CxWSResponseScanResultsPriority response)
+        {
+            var mappedResponse = Utils.Map<PortalSoap.CxWSResponceScanResults>(response);
+            mappedResponse.Results = response.Results?.Select(x => MapPriorityResultToSoapResult(x)).ToArray();
+
+            return mappedResponse;
+        }
+
+        private PortalSoap.CxWSSingleResultData MapPriorityResultToSoapResult(CxWSSingleResultDataPriority result)
+        {
+            if (result == null)
+                throw new ArgumentNullException(nameof(result));
+
+            var mappedResult = Utils.Map<PortalSoap.CxWSSingleResultData>(result);
+
+            switch (result.ResultStatus)
+            {
+                case CompareStatusType.New:
+                    mappedResult.ResultStatus = PortalSoap.CompareStatusType.New;
+                    break;
+                case CompareStatusType.Reoccured:
+                    mappedResult.ResultStatus = PortalSoap.CompareStatusType.Reoccured;
+                    break;
+                case CompareStatusType.Fixed:
+                    mappedResult.ResultStatus = PortalSoap.CompareStatusType.Fixed;
+                    break;
+                default:
+                    throw new NotSupportedException($"Priority API result status \"{result.ResultStatus.ToString()}\" not supported.");
+            }
+
+            return mappedResult;
+        }
+
+        #endregion
     }
 }

--- a/Checkmarx.API/Connected Services/cxPriorityWebService/Reference.cs
+++ b/Checkmarx.API/Connected Services/cxPriorityWebService/Reference.cs
@@ -1650,11 +1650,6 @@ namespace cxPriorityWebService
             return base.Channel.GetResultsForScan(request);
         }
 
-        internal PortalSoap.CxWSResponceScanResults GetMappedResultsForScan(string sessionID, long scanId)
-        {
-            return MapPriorityResultsToSoapResults(GetResultsForScan(sessionID, scanId));
-        }
-
         public cxPriorityWebService.CxWSResponseScanResultsPriority GetResultsForScan(string sessionID, long scanId)
         {
             cxPriorityWebService.GetResultsForScanRequest inValue = new cxPriorityWebService.GetResultsForScanRequest();
@@ -1962,42 +1957,5 @@ namespace cxPriorityWebService
             
             CxPriorityServiceSoap12,
         }
-
-        #region Mapping
-
-        private PortalSoap.CxWSResponceScanResults MapPriorityResultsToSoapResults(cxPriorityWebService.CxWSResponseScanResultsPriority response)
-        {
-            var mappedResponse = Utils.Map<PortalSoap.CxWSResponceScanResults>(response);
-            mappedResponse.Results = response.Results?.Select(x => MapPriorityResultToSoapResult(x)).ToArray();
-
-            return mappedResponse;
-        }
-
-        private PortalSoap.CxWSSingleResultData MapPriorityResultToSoapResult(CxWSSingleResultDataPriority result)
-        {
-            if (result == null)
-                throw new ArgumentNullException(nameof(result));
-
-            var mappedResult = Utils.Map<PortalSoap.CxWSSingleResultData>(result);
-
-            switch (result.ResultStatus)
-            {
-                case CompareStatusType.New:
-                    mappedResult.ResultStatus = PortalSoap.CompareStatusType.New;
-                    break;
-                case CompareStatusType.Reoccured:
-                    mappedResult.ResultStatus = PortalSoap.CompareStatusType.Reoccured;
-                    break;
-                case CompareStatusType.Fixed:
-                    mappedResult.ResultStatus = PortalSoap.CompareStatusType.Fixed;
-                    break;
-                default:
-                    throw new NotSupportedException($"Priority API result status \"{result.ResultStatus.ToString()}\" not supported.");
-            }
-
-            return mappedResult;
-        }
-
-        #endregion
     }
 }

--- a/Checkmarx.API/CxClient.cs
+++ b/Checkmarx.API/CxClient.cs
@@ -2744,7 +2744,7 @@ namespace Checkmarx.API
         }
 
         private cxPortalWebService93.CxWSQueryGroup[] _queryGroupCache = null;
-        public Dictionary<cxPortalWebService93.CxWSQuery, cxPortalWebService93.CxWSQueryGroup> GetQueriesByLanguageAndOrName(string language, string queryName)
+        public Dictionary<cxPortalWebService93.CxWSQuery, cxPortalWebService93.CxWSQueryGroup> GetQueriesByLanguageAndOrName(string language, string queryName, bool onlyExecutable = false)
         {
             if (string.IsNullOrWhiteSpace(language) && string.IsNullOrWhiteSpace(queryName))
                 throw new NullReferenceException("Between language and query name, at least one must have a value.");
@@ -2763,7 +2763,7 @@ namespace Checkmarx.API
                     {
                         foreach (var g in selectedGroups)
                         {
-                            foreach (var q in g.Queries)
+                            foreach (var q in g.Queries.Where(x => !onlyExecutable || x.IsExecutable))
                             {
                                 if (q.Name.ToLower() == queryName.Trim().ToLower())
                                     foundQueries.Add(q, g);
@@ -2774,7 +2774,7 @@ namespace Checkmarx.API
                     {
                         foreach (var g in selectedGroups)
                         {
-                            foreach (var q in g.Queries)
+                            foreach (var q in g.Queries.Where(x => !onlyExecutable || x.IsExecutable))
                                 foundQueries.Add(q, g);
                         }
                     }
@@ -2786,7 +2786,7 @@ namespace Checkmarx.API
                 {
                     foreach (var g in _queryGroupCache)
                     {
-                        foreach (var q in g.Queries)
+                        foreach (var q in g.Queries.Where(x => !onlyExecutable || x.IsExecutable))
                         {
                             if (q.Name.ToLower() == queryName.Trim().ToLower())
                                 foundQueries.Add(q, g);

--- a/Checkmarx.API/CxClient.cs
+++ b/Checkmarx.API/CxClient.cs
@@ -3395,7 +3395,11 @@ namespace Checkmarx.API
         {
             checkConnection();
 
-            var result = _cxPortalWebServiceSoapClient.GetResultsForScan(_soapSessionId, scanId);
+            CxWSResponceScanResults result = null;
+            if(_isV95)
+                result = _cxPriorityServiceSoapClient.GetMappedResultsForScan(_soapSessionId, scanId);
+            else
+                result = _cxPortalWebServiceSoapClient.GetResultsForScan(_soapSessionId, scanId);
 
             if (!result.IsSuccesfull)
                 throw new ApplicationException(result.ErrorMessage);
@@ -3413,7 +3417,7 @@ namespace Checkmarx.API
                                              x.State != (int)ResultState.ProposedNotExploitable).ToArray();
             }
 
-            return results.Cast<CxWSSingleResultData>();
+            return results;
         }
 
         public CxWSSingleResultData[] GetResultsForScanNeitherConfirmedNorNonExploitable(long scanId, bool includeInfoSeverityResults = true)

--- a/Checkmarx.API/CxClient.cs
+++ b/Checkmarx.API/CxClient.cs
@@ -554,8 +554,10 @@ namespace Checkmarx.API
         }
 
         private bool _isV9 = false;
+        private bool _isV94 = false;
         private bool _isV95 = false;
 
+        public bool IsV94 { get { return _isV94; } }
         public bool IsV95 { get { return _isV95; } }
 
         #region Access Control 
@@ -634,7 +636,10 @@ namespace Checkmarx.API
             _isV9 = _version.Major >= 9;
 
             if (_isV9)
+            {
+                _isV94 = _version.Minor >= 4;
                 _isV95 = _version.Minor >= 5;
+            }
 
             Console.WriteLine("Checkmarx " + _version.ToString());
 
@@ -3392,20 +3397,19 @@ namespace Checkmarx.API
             return GetResultsForScan(scanId, includeInfoSeverityResults).Where(x => x.State == (int)state);
         }
 
-        public IEnumerable<SoapSingleResultData> GetResultsForScan(long scanId, bool includeInfoSeverityResults = true, bool includeNonExploitables = true, bool usePriority = false)
+        public IEnumerable<SoapSingleResultData> GetResultsForScan(long scanId, bool includeInfoSeverityResults = true, bool includeNonExploitables = true)
         {
             checkConnection();
 
             IEnumerable<SoapSingleResultData> results = null;
-            //if (_isV95)
-            if (usePriority)
+            if (_isV94)
             {
                 var response = _cxPriorityServiceSoapClient.GetResultsForScan(_soapSessionId, scanId);
 
                 if (!response.IsSuccesfull)
                     throw new ApplicationException(response.ErrorMessage);
 
-                results = response.Results.Select(x => Mapper.MapPrioritySingleResultData(x));
+                results = response.Results?.Select(x => Mapper.MapPrioritySingleResultData(x));
             }
             else
             {
@@ -3414,7 +3418,7 @@ namespace Checkmarx.API
                 if (!response.IsSuccesfull)
                     throw new ApplicationException(response.ErrorMessage);
 
-                results = response.Results.Select(x => Mapper.MapSoapSingleResultData(x));
+                results = response.Results?.Select(x => Mapper.MapSoapSingleResultData(x));
             }
 
             if (!includeInfoSeverityResults)

--- a/Checkmarx.API/Mapper.cs
+++ b/Checkmarx.API/Mapper.cs
@@ -1,0 +1,125 @@
+﻿using Checkmarx.API.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Checkmarx.API
+{
+    public static class Mapper
+    {
+        public static T Map<T>(object oldObject) where T : new()
+        {
+            if (oldObject == null)
+                throw new ArgumentNullException(nameof(oldObject));
+
+            // Create a new object of type TDATA
+            T newObject = new T();
+            try
+            {
+                // If the old object is null, just return the new object
+                if (oldObject == null) return newObject;
+
+                // Get the type of the new object and the type of the old object passed in
+                Type newObjType = typeof(T);
+                Type oldObjType = oldObject.GetType();
+
+                // Get a list of all the properties in the new object
+                var propertyList = newObjType.GetProperties();
+
+                // If the new object has properties
+                if (propertyList.Length > 0)
+                {
+                    // Loop through each property in the new object
+                    foreach (var newObjProp in propertyList)
+                    {
+                        // Get the corresponding property in the old object
+                        var oldProp = oldObjType.GetProperty(newObjProp.Name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.IgnoreCase | BindingFlags.ExactBinding);
+
+                        // If there is a corresponding property in the old object and it can be read and the new object's property can be written to
+                        if (oldProp != null && oldProp.CanRead && newObjProp.CanWrite)
+                        {
+                            // assign property type of both object to new variables
+                            var oldPropertyType = oldProp.PropertyType;
+                            var newPropertyType = newObjProp.PropertyType;
+
+                            //check if property is nullable or not. if property is nullable then get it's original data type from generic argument
+                            if (oldPropertyType.IsGenericType && oldPropertyType.GetGenericTypeDefinition() == typeof(Nullable<>)) oldPropertyType = oldPropertyType.GetGenericArguments()[0];
+
+                            if (newPropertyType.IsGenericType && newPropertyType.GetGenericTypeDefinition() == typeof(Nullable<>)) newPropertyType = newPropertyType.GetGenericArguments()[0];
+
+                            //check type of both property if match then set value
+                            if (newPropertyType == oldPropertyType)
+                            {
+                                // Get the value of the property in the old object
+                                var value = oldProp.GetValue(oldObject);
+
+                                // Set the value of the property in the new object
+                                newObjProp.SetValue(newObject, value);
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                throw;
+            }
+
+            // Return the new object
+            return newObject;
+        }
+
+        public static SoapSingleResultData MapSoapSingleResultData(PortalSoap.CxWSSingleResultData data)
+        {
+            if (data == null)
+                throw new ArgumentNullException(nameof(data));
+
+            var result = Map<SoapSingleResultData>(data);
+
+            switch (data.ResultStatus)
+            {
+                case PortalSoap.CompareStatusType.New:
+                    result.ResultStatus = ResultStatus.New;
+                    break;
+                case PortalSoap.CompareStatusType.Reoccured:
+                    result.ResultStatus = ResultStatus.Reoccured;
+                    break;
+                case PortalSoap.CompareStatusType.Fixed:
+                    result.ResultStatus = ResultStatus.Fixed;
+                    break;
+                default:
+                    throw new NotSupportedException($"Priority API result status \"{data.ResultStatus.ToString()}\" not supported.");
+            }
+
+            return result;
+        }
+
+        public static PrioritySingleResultData MapPrioritySingleResultData(cxPriorityWebService.CxWSSingleResultDataPriority data)
+        {
+            if (data == null)
+                throw new ArgumentNullException(nameof(data));
+
+            var result = Map<PrioritySingleResultData>(data);
+
+            switch (data.ResultStatus)
+            {
+                case cxPriorityWebService.CompareStatusType.New:
+                    result.ResultStatus = ResultStatus.New;
+                    break;
+                case cxPriorityWebService.CompareStatusType.Reoccured:
+                    result.ResultStatus = ResultStatus.Reoccured;
+                    break;
+                case cxPriorityWebService.CompareStatusType.Fixed:
+                    result.ResultStatus = ResultStatus.Fixed;
+                    break;
+                default:
+                    throw new NotSupportedException($"Priority API result status \"{data.ResultStatus.ToString()}\" not supported.");
+            }
+
+            return result;
+        }
+    }
+}

--- a/Checkmarx.API/Models/PrioritySingleResultData.cs
+++ b/Checkmarx.API/Models/PrioritySingleResultData.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Checkmarx.API.Models
+{
+    public class PrioritySingleResultData : SoapSingleResultData
+    {
+        public long SimilarityID { get; set; }
+
+        public System.Nullable<double> CxRank { get; set; }
+
+        public string BflNodeShortName { get; set; }
+
+        public System.Nullable<int> BflGroupSize { get; set; }
+
+        public System.Nullable<System.DateTime> Date { get; set; }
+    }
+}

--- a/Checkmarx.API/Models/SoapSingleResultData.cs
+++ b/Checkmarx.API/Models/SoapSingleResultData.cs
@@ -1,0 +1,60 @@
+﻿using Checkmarx.API.OSA;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace Checkmarx.API.Models
+{
+    public class SoapSingleResultData
+    {
+        public long QueryId { get; set; }
+
+        public long PathId { get; set; }
+
+        public string SourceFolder { get; set; }
+
+        public string SourceFile { get; set; }
+
+        public long SourceLine { get; set; }
+
+        public string SourceObject { get; set; }
+
+        public string DestFolder { get; set; }
+
+        public string DestFile { get; set; }
+
+        public long DestLine { get; set; }
+
+        public int NumberOfNodes { get; set; }
+
+        public string DestObject { get; set; }
+
+        public string Comment { get; set; }
+
+        public int State { get; set; }
+
+        public int Severity { get; set; }
+
+        public string AssignedUser { get; set; }
+
+        public System.Nullable<int> ConfidenceLevel { get; set; }
+
+        public ResultStatus ResultStatus { get; set; }
+
+        public string IssueTicketID { get; set; }
+
+        public long QueryVersionCode { get; set; }
+    }
+
+    public enum ResultStatus
+    {
+        Fixed,
+        Reoccured,
+        New,
+    }
+}

--- a/Checkmarx.API/Utils.cs
+++ b/Checkmarx.API/Utils.cs
@@ -1,4 +1,5 @@
-﻿using CxDataRepository;
+﻿using Checkmarx.API.Models;
+using CxDataRepository;
 using cxPortalWebService93;
 using Newtonsoft.Json.Linq;
 using System;
@@ -11,7 +12,7 @@ namespace Checkmarx.API
 {
     public static class Utils
     {
-        public static Uri GetLink(this CxWSSingleResultData result)
+        public static Uri GetLink(this SoapSingleResultData result)
         {
             return new Uri(result.PathId.ToString());
         }
@@ -22,7 +23,7 @@ namespace Checkmarx.API
         /// <param name="result"></param>
         /// <param name="clientV93"></param>
         /// <returns></returns>
-        public static Uri GetLink(this PortalSoap.CxWSSingleResultData result, CxClient clientV93, long projectId, long scanId)
+        public static Uri GetLink(this SoapSingleResultData result, CxClient clientV93, long projectId, long scanId)
         {
             return new Uri(clientV93.SASTServerURL, $"cxwebclient/ViewerMain.aspx?scanid={scanId}&projectid={projectId}&pathid={result.PathId}");
         }
@@ -40,65 +41,6 @@ namespace Checkmarx.API
         public static Uri GetLink(this Checkmarx.API.SAST.OData.Result item, CxClient clientV94, long projectId, long scanId)
         {
             return new Uri(clientV94.SASTServerURL, $"cxwebclient/ViewerMain.aspx?scanid={scanId}&projectid={projectId}&pathid={item.PathId}");
-        }
-
-        public static T Map<T>(object oldObject) where T : new()
-        {
-            // Create a new object of type TDATA
-            T newObject = new T();
-            try
-            {
-                // If the old object is null, just return the new object
-                if (oldObject == null) return newObject;
-
-                // Get the type of the new object and the type of the old object passed in
-                Type newObjType = typeof(T);
-                Type oldObjType = oldObject.GetType();
-
-                // Get a list of all the properties in the new object
-                var propertyList = newObjType.GetProperties();
-
-                // If the new object has properties
-                if (propertyList.Length > 0)
-                {
-                    // Loop through each property in the new object
-                    foreach (var newObjProp in propertyList)
-                    {
-                        // Get the corresponding property in the old object
-                        var oldProp = oldObjType.GetProperty(newObjProp.Name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.IgnoreCase | BindingFlags.ExactBinding);
-
-                        // If there is a corresponding property in the old object and it can be read and the new object's property can be written to
-                        if (oldProp != null && oldProp.CanRead && newObjProp.CanWrite)
-                        {
-                            // assign property type of both object to new variables
-                            var oldPropertyType = oldProp.PropertyType;
-                            var newPropertyType = newObjProp.PropertyType;
-
-                            //check if property is nullable or not. if property is nullable then get it's original data type from generic argument
-                            if (oldPropertyType.IsGenericType && oldPropertyType.GetGenericTypeDefinition() == typeof(Nullable<>)) oldPropertyType = oldPropertyType.GetGenericArguments()[0];
-
-                            if (newPropertyType.IsGenericType && newPropertyType.GetGenericTypeDefinition() == typeof(Nullable<>)) newPropertyType = newPropertyType.GetGenericArguments()[0];
-
-                            //check type of both property if match then set value
-                            if (newPropertyType == oldPropertyType)
-                            {
-                                // Get the value of the property in the old object
-                                var value = oldProp.GetValue(oldObject);
-
-                                // Set the value of the property in the new object
-                                newObjProp.SetValue(newObject, value);
-                            }
-                        }
-                    }
-                }
-            }
-            catch (Exception)
-            {
-                throw;
-            }
-
-            // Return the new object
-            return newObject;
         }
     }
 }

--- a/Checkmarx.API/Utils.cs
+++ b/Checkmarx.API/Utils.cs
@@ -1,7 +1,10 @@
 ﻿using CxDataRepository;
 using cxPortalWebService93;
+using Newtonsoft.Json.Linq;
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Text;
 
 namespace Checkmarx.API
@@ -37,6 +40,65 @@ namespace Checkmarx.API
         public static Uri GetLink(this Checkmarx.API.SAST.OData.Result item, CxClient clientV94, long projectId, long scanId)
         {
             return new Uri(clientV94.SASTServerURL, $"cxwebclient/ViewerMain.aspx?scanid={scanId}&projectid={projectId}&pathid={item.PathId}");
+        }
+
+        public static T Map<T>(object oldObject) where T : new()
+        {
+            // Create a new object of type TDATA
+            T newObject = new T();
+            try
+            {
+                // If the old object is null, just return the new object
+                if (oldObject == null) return newObject;
+
+                // Get the type of the new object and the type of the old object passed in
+                Type newObjType = typeof(T);
+                Type oldObjType = oldObject.GetType();
+
+                // Get a list of all the properties in the new object
+                var propertyList = newObjType.GetProperties();
+
+                // If the new object has properties
+                if (propertyList.Length > 0)
+                {
+                    // Loop through each property in the new object
+                    foreach (var newObjProp in propertyList)
+                    {
+                        // Get the corresponding property in the old object
+                        var oldProp = oldObjType.GetProperty(newObjProp.Name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.IgnoreCase | BindingFlags.ExactBinding);
+
+                        // If there is a corresponding property in the old object and it can be read and the new object's property can be written to
+                        if (oldProp != null && oldProp.CanRead && newObjProp.CanWrite)
+                        {
+                            // assign property type of both object to new variables
+                            var oldPropertyType = oldProp.PropertyType;
+                            var newPropertyType = newObjProp.PropertyType;
+
+                            //check if property is nullable or not. if property is nullable then get it's original data type from generic argument
+                            if (oldPropertyType.IsGenericType && oldPropertyType.GetGenericTypeDefinition() == typeof(Nullable<>)) oldPropertyType = oldPropertyType.GetGenericArguments()[0];
+
+                            if (newPropertyType.IsGenericType && newPropertyType.GetGenericTypeDefinition() == typeof(Nullable<>)) newPropertyType = newPropertyType.GetGenericArguments()[0];
+
+                            //check type of both property if match then set value
+                            if (newPropertyType == oldPropertyType)
+                            {
+                                // Get the value of the property in the old object
+                                var value = oldProp.GetValue(oldObject);
+
+                                // Set the value of the property in the new object
+                                newObjProp.SetValue(newObject, value);
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                throw;
+            }
+
+            // Return the new object
+            return newObject;
         }
     }
 }


### PR DESCRIPTION
- New models SoapSingleResultData and PrioritySingleResultData
- New bool to check if version is 9.4 or higher
- GetResultsForScan calls PortalSoap or Priority API denpending on version. Always returns type SoapSingleResultData