### PR TITLE
Fix to GetScans comparing dates and changes to GetPresetQueryId

### DIFF
--- a/Checkmarx.API.Tests/ScanTests.cs
+++ b/Checkmarx.API.Tests/ScanTests.cs
@@ -914,5 +914,19 @@ namespace Checkmarx.API.Tests
                 }
             }
         }
+
+        [TestMethod]
+        public void FetchScansByDateTest()
+        {
+            var filterDate = new DateTime(2024, 6, 23, 0, 3, 0);
+
+            var scanBefore = clientV93.GetScans(18096, true, scanKind: CxClient.ScanRetrieveKind.Last, maxScanDate: filterDate, includeGhostScans: false).SingleOrDefault();
+
+            Trace.WriteLine($"Scan Before: {scanBefore.Id}");
+
+            var scanAfter = clientV93.GetScans(18096, true, scanKind: CxClient.ScanRetrieveKind.First, minScanDate: filterDate, includeGhostScans: false).SingleOrDefault();
+
+            Trace.WriteLine($"Scan After: {scanAfter.Id}");
+        }
     }
 }


### PR DESCRIPTION
- Fix to GetScans wrongly comparing ScanRequestedOn with a diffrent OffSet.
- Changes to GetScans in order to filter first and then return all, first or last. 
- Changed GetPresetQueryId in order to check queries includig the inactive ones.