### PR TITLE
OData timeout policy

### DIFF
--- a/Checkmarx.API/CxClient.cs
+++ b/Checkmarx.API/CxClient.cs
@@ -4162,7 +4162,8 @@ namespace Checkmarx.API
         {
             checkConnection();
 
-            var response = _cxPortalWebServiceSoapClient.UpdateSetOfResultState(_soapSessionId, results);
+            var response = _soapRetryPolicyProvider.ExecuteWithRetry(
+                () => _cxPortalWebServiceSoapClient.UpdateSetOfResultState(_soapSessionId, results));
 
             checkSoapResponse(response);
         }

--- a/Checkmarx.API/Models/RetryableDataServiceQuery.cs
+++ b/Checkmarx.API/Models/RetryableDataServiceQuery.cs
@@ -1,14 +1,15 @@
 ﻿using Microsoft.OData.Client;
 using Polly;
+using Polly.Timeout;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
+using System.Threading.Tasks;
 
 namespace Checkmarx.API.Models
 {
@@ -16,8 +17,8 @@ namespace Checkmarx.API.Models
     {
         private readonly IQueryable<T> _innerQuery;
         private readonly int _retryCount;
-        private readonly Policy<IEnumerable<T>> _retryPolicy;
-        private readonly Policy<object> _genericRetryPolicy;
+        private readonly ISyncPolicy<IEnumerable<T>> _retryPolicy;
+        private readonly ISyncPolicy<object> _genericRetryPolicy;
         private readonly RetryableQueryProvider<T> _retryableProvider;
 
         public RetryableDataServiceQuery(IQueryable<T> innerQuery, int retryCount = 10)
@@ -111,22 +112,46 @@ namespace Checkmarx.API.Models
             Console.WriteLine($"Retry {retryAttempt} after {timespan.TotalSeconds:F1} seconds due to: {message}");
         }
 
-        private static Policy<IEnumerable<T>> buildRetryPolicy(int retries)
+        private static ISyncPolicy<IEnumerable<T>> buildRetryPolicy(int retries)
         {
-            return Policy<IEnumerable<T>>
+            var timeoutPolicy = Policy.Timeout<IEnumerable<T>>(
+                TimeSpan.FromHours(1),
+                TimeoutStrategy.Pessimistic,
+                onTimeout: (context, timespan, task) =>
+                    Console.WriteLine($"OData request timed out after {timespan.TotalSeconds} seconds."));
+
+            var retryPolicy = Policy<IEnumerable<T>>
                 .Handle<DataServiceQueryException>(isTransientError)
                 .Or<HttpRequestException>(isTransientError)
                 .Or<WebException>(isTransientWebError)
+                .Or<TaskCanceledException>(isRetryableTaskCanceled)
                 .WaitAndRetry(retries, getRetryDelay, onRetry);
+
+            return retryPolicy.Wrap(timeoutPolicy);
         }
 
-        private static Policy<object> buildGenericRetryPolicy(int retries)
+        private static ISyncPolicy<object> buildGenericRetryPolicy(int retries)
         {
-            return Policy<object>
+            var timeoutPolicy = Policy.Timeout<object>(
+                TimeSpan.FromHours(1),
+                TimeoutStrategy.Pessimistic,
+                onTimeout: (context, timespan, task) =>
+                    Console.WriteLine($"OData request timed out after {timespan.TotalSeconds} seconds."));
+
+            var retryPolicy = Policy<object>
                 .Handle<DataServiceQueryException>(isTransientError)
                 .Or<HttpRequestException>(isTransientError)
                 .Or<WebException>(isTransientWebError)
+                .Or<TaskCanceledException>(isRetryableTaskCanceled)
                 .WaitAndRetry(retries, getRetryDelay, onRetry);
+
+            return retryPolicy.Wrap(timeoutPolicy);
+        }
+
+        private static bool isRetryableTaskCanceled(TaskCanceledException ex)
+        {
+            // Retry only on HTTP-layer timeouts, not on explicit user/application cancellations
+            return !ex.CancellationToken.IsCancellationRequested;
         }
 
         private static bool isTransientError(DataServiceQueryException ex)
@@ -169,11 +194,11 @@ namespace Checkmarx.API.Models
     public class RetryableQueryProvider<T> : IQueryProvider
     {
         private readonly IQueryProvider _innerProvider;
-        private readonly Policy<IEnumerable<T>> _retryPolicy;
-        private readonly Policy<object> _genericRetryPolicy;
+        private readonly ISyncPolicy<IEnumerable<T>> _retryPolicy;
+        private readonly ISyncPolicy<object> _genericRetryPolicy;
         private readonly int _retryCount;
 
-        public RetryableQueryProvider(IQueryProvider innerProvider, Policy<IEnumerable<T>> retryPolicy, Policy<object> genericRetryPolicy, int retryCount = 10)
+        public RetryableQueryProvider(IQueryProvider innerProvider, ISyncPolicy<IEnumerable<T>> retryPolicy, ISyncPolicy<object> genericRetryPolicy, int retryCount = 10)
         {
             _innerProvider = innerProvider;
             _retryPolicy = retryPolicy;

--- a/Checkmarx.API/Models/SOAPRetryPolicyProvider.cs
+++ b/Checkmarx.API/Models/SOAPRetryPolicyProvider.cs
@@ -1,5 +1,5 @@
 ﻿using Polly;
-using Polly.Retry;
+using Polly.Timeout;
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
@@ -39,21 +39,21 @@ namespace Checkmarx.API.Models
 
         #region Private Helpers
 
-        private RetryPolicy<T> GetOrCreateSyncPolicy<T>(int retries)
+        private ISyncPolicy<T> GetOrCreateSyncPolicy<T>(int retries)
         {
             int effectiveRetries = retries > 0 ? retries : _defaultRetries;
 
-            return (RetryPolicy<T>)_syncPolicyCache.GetOrAdd(
+            return (ISyncPolicy<T>)_syncPolicyCache.GetOrAdd(
                 (typeof(T), effectiveRetries),
                 _ => BuildRetryPolicy<T>(effectiveRetries)
             );
         }
 
-        private AsyncRetryPolicy<T> GetOrCreateAsyncPolicy<T>(int retries)
+        private IAsyncPolicy<T> GetOrCreateAsyncPolicy<T>(int retries)
         {
             int effectiveRetries = retries > 0 ? retries : _defaultRetries;
 
-            return (AsyncRetryPolicy<T>)_asyncPolicyCache.GetOrAdd(
+            return (IAsyncPolicy<T>)_asyncPolicyCache.GetOrAdd(
                 (typeof(T), effectiveRetries),
                 _ => BuildAsyncRetryPolicy<T>(effectiveRetries)
             );
@@ -63,9 +63,15 @@ namespace Checkmarx.API.Models
 
         #region Policy Builders
 
-        private static RetryPolicy<T> BuildRetryPolicy<T>(int retries)
+        private static ISyncPolicy<T> BuildRetryPolicy<T>(int retries)
         {
-            return Policy<T>
+            var timeoutPolicy = Policy.Timeout<T>(
+                TimeSpan.FromHours(1),
+                TimeoutStrategy.Pessimistic,
+                onTimeout: (context, timespan, task) =>
+                    Console.WriteLine($"SOAP request timed out after {timespan.TotalSeconds} seconds."));
+
+            var retryPolicy = Policy<T>
                 .Handle<FaultException>()
                 .Or<WebException>(IsTransientError)
                 .Or<AggregateException>(IsTransientError)
@@ -75,14 +81,24 @@ namespace Checkmarx.API.Models
                 .WaitAndRetry(
                     retryCount: retries,
                     sleepDurationProvider: (retryAttempt, outcome, context) => GetRetryDelayExponential<T>(outcome, retryAttempt),
-                    //retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
                     onRetry: (outcome, timeSpan, retryCount, context) => OnRetry(outcome, timeSpan, retryCount, context)
                 );
+
+            return retryPolicy.Wrap(timeoutPolicy);
         }
 
-        private static AsyncRetryPolicy<T> BuildAsyncRetryPolicy<T>(int retries)
+        private static IAsyncPolicy<T> BuildAsyncRetryPolicy<T>(int retries)
         {
-            return Policy<T>
+            var timeoutPolicy = Policy.TimeoutAsync<T>(
+                TimeSpan.FromHours(1),
+                TimeoutStrategy.Pessimistic,
+                onTimeoutAsync: (context, timespan, task) =>
+                {
+                    Console.WriteLine($"SOAP request timed out after {timespan.TotalSeconds} seconds.");
+                    return Task.CompletedTask;
+                });
+
+            var retryPolicy = Policy<T>
                 .Handle<FaultException>()
                 .Or<WebException>(IsTransientError)
                 .Or<AggregateException>(IsTransientError)
@@ -92,10 +108,11 @@ namespace Checkmarx.API.Models
                 .WaitAndRetryAsync(
                     retryCount: retries,
                     sleepDurationProvider: (retryAttempt, outcome, context) => GetRetryDelayExponential<T>(outcome, retryAttempt),
-                    //retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
                     onRetryAsync: async (outcome, timeSpan, retryCount, context) =>
                         await OnRetryAsync(outcome, timeSpan, retryCount, context)
                 );
+
+            return retryPolicy.WrapAsync(timeoutPolicy);
         }
 
 


### PR DESCRIPTION
Added missing timeout policy to OData calls (RetryableDataServiceQuery).
Added separate timeout policy to SOAPRetryPolicyProvider.
Wrapped UpdateSetOfResultState with a retry provider.